### PR TITLE
[SP-6635] Backport of PPP-4895 - Vulnerable Component: Jettison

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
   <dependency>
     <groupId>org.codehaus.jettison</groupId>
     <artifactId>jettison</artifactId>
-    <version>1.2</version>
+    <version>${jettison.version}</version>
   </dependency>
   <!-- test dependencies -->
   <dependency>


### PR DESCRIPTION
- [PPP-4895] Upgrade jettison to version 1.5.4

[PPP-4895]: https://hv-eng.atlassian.net/browse/PPP-4895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ